### PR TITLE
fix: Add handling of aws codepipeline in version variables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2022-07-29 (2.16.2)
 - Fixes a bug introduced in 2.16.0, AWS pipelines weren't able to get the branch name of the repository.
+- Add override for lambda version
 
 2022-07-28 (2.16.1)
 - Added trim function to handle invalid characters

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2022-07-29 (2.16.2)
+- Fixes a bug introduced in 2.16.0, AWS pipelines weren't able to get the branch name of the repository.
+
 2022-07-28 (2.16.1)
 - Added trim function to handle invalid characters
 

--- a/libs/logic.js
+++ b/libs/logic.js
@@ -255,8 +255,9 @@ async function publish(args, config = {}) {
     console.log('[Config] Update lambda Environment Configuration');
 
     // versioning
-    info.Environment.Variables.VERSION = `${currentBranchName}_${lastCommitId}`;
-    info.Environment.Variables.DD_VERSION = `${currentBranchName.split('/')[1] ?? currentBranchName}_${lastCommitId}`;
+    const env_version=
+    info.Environment.Variables.VERSION = `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
+    info.Environment.Variables.DD_VERSION = `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? currentBranchName}_${lastCommitId}`;
 
     updateCreateFnParams.Environment = {
       Variables: info.Environment.Variables || info.Environment,

--- a/libs/logic.js
+++ b/libs/logic.js
@@ -257,7 +257,7 @@ async function publish(args, config = {}) {
     // versioning
     const env_version=
     info.Environment.Variables.VERSION = `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
-    info.Environment.Variables.DD_VERSION = `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? currentBranchName}_${lastCommitId}`;
+    info.Environment.Variables.DD_VERSION = `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? (process.env.AWS_BRANCH_NAME || currentBranchName)}_${lastCommitId}`;
 
     updateCreateFnParams.Environment = {
       Variables: info.Environment.Variables || info.Environment,

--- a/libs/logic.js
+++ b/libs/logic.js
@@ -255,8 +255,8 @@ async function publish(args, config = {}) {
     console.log('[Config] Update lambda Environment Configuration');
 
     // versioning
-    info.Environment.Variables.VERSION = `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
-    info.Environment.Variables.DD_VERSION = `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? (process.env.AWS_BRANCH_NAME || currentBranchName)}_${lastCommitId}`;
+    info.Environment.Variables.VERSION = process.env.VERSION || `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
+    info.Environment.Variables.DD_VERSION = process.env.VERSION || `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? (process.env.AWS_BRANCH_NAME || currentBranchName)}_${lastCommitId}`;
 
     updateCreateFnParams.Environment = {
       Variables: info.Environment.Variables || info.Environment,

--- a/libs/logic.js
+++ b/libs/logic.js
@@ -255,7 +255,6 @@ async function publish(args, config = {}) {
     console.log('[Config] Update lambda Environment Configuration');
 
     // versioning
-    const env_version=
     info.Environment.Variables.VERSION = `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
     info.Environment.Variables.DD_VERSION = `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? (process.env.AWS_BRANCH_NAME || currentBranchName)}_${lastCommitId}`;
 


### PR DESCRIPTION
This PR fixes a bug when deploying through pipelines on AWS.

When CodeBuild runs yadu, `currentBranchName` get set to `unknown-branch`. 
This was already handled in the `description` field of the lambdas, this trick was copied over to the `info.Environment.Variables.VERSION` and `info.Environment.Variables.DD_VERSION` variables.