### PR TITLE
Release 2.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@halfserious/yadu",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halfserious/yadu",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "Package and Deploy our AWS lambdas",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
# Release 2.16.2
- Fixes a bug introduced in 2.16.0, AWS pipelines weren't able to get the branch name of the repository.
- Add override for lambda version