### PR TITLE
fix: the VERSION variable was already set in the pipelines and cannot…

### DIFF
--- a/libs/logic.js
+++ b/libs/logic.js
@@ -255,8 +255,13 @@ async function publish(args, config = {}) {
     console.log('[Config] Update lambda Environment Configuration');
 
     // versioning
-    info.Environment.Variables.VERSION = process.env.VERSION || `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
-    info.Environment.Variables.DD_VERSION = process.env.VERSION || `${(process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? (process.env.AWS_BRANCH_NAME || currentBranchName)}_${lastCommitId}`;
+    info.Environment.Variables.VERSION =
+      process.env.CUSTOM_VERSION || `${process.env.AWS_BRANCH_NAME || currentBranchName.replace('\n', '')}_${lastCommitId}`;
+    info.Environment.Variables.DD_VERSION =
+      process.env.CUSTOM_VERSION ||
+      `${
+        (process.env.AWS_BRANCH_NAME || currentBranchName).split('/')[1] ?? (process.env.AWS_BRANCH_NAME || currentBranchName)
+      }_${lastCommitId}`;
 
     updateCreateFnParams.Environment = {
       Variables: info.Environment.Variables || info.Environment,


### PR DESCRIPTION
The `VERSION` environment variable was already set in the pipelines and cannot be used for versioning